### PR TITLE
Feature add fields

### DIFF
--- a/migrations/2021_07_30_093500_create_binshops_fields_table.php
+++ b/migrations/2021_07_30_093500_create_binshops_fields_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateBinshopFieldsTable extends Migration
+class CreateBinshopsFieldsTable extends Migration
 {
     /**
      * Run the migrations.

--- a/migrations/2021_07_30_093500_create_binshops_fields_table.php
+++ b/migrations/2021_07_30_093500_create_binshops_fields_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBinshopFieldsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('binshops_fields', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('label');
+            $table->string('type');
+            $table->string('validation')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('binshops_fields');
+    }
+}

--- a/migrations/2021_07_30_093500_create_binshops_fields_table.php
+++ b/migrations/2021_07_30_093500_create_binshops_fields_table.php
@@ -15,7 +15,9 @@ class CreateBinshopFieldsTable extends Migration
     {
         Schema::create('binshops_fields', function (Blueprint $table) {
             $table->increments('id');
+            $table->string('name');
             $table->string('label');
+            $table->string('help');
             $table->string('type');
             $table->string('validation')->nullable();
             $table->timestamps();

--- a/migrations/2021_07_30_093600_create_binshops_fields_values_table.php
+++ b/migrations/2021_07_30_093600_create_binshops_fields_values_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBinshopsFieldsValuesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('binshops_field_values', function (Blueprint $table) {
+            $table->increments('id');
+
+            $table->unsignedInteger('field_id');
+            $table->foreign('field_id')->references('id')->on('binshops_fields');
+
+            $table->unsignedInteger('post_id');
+            $table->foreign('post_id')->references('id')->on('binshops_posts');
+            $table->string("value");
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('binshops_field_values');
+    }
+}

--- a/migrations/2021_07_30_093700_create_binshops_fields_categories_table.php
+++ b/migrations/2021_07_30_093700_create_binshops_fields_categories_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBinshopFieldsCategoriesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('binshops_field_categories', function (Blueprint $table) {
+            $table->increments('id');
+            $table->unsignedInteger('category_id');
+            $table->foreign('category_id')->references('id')->on('binshops_categories');
+
+            $table->unsignedInteger('field_id');
+            $table->foreign('field_id')->references('id')->on('binshops_fields');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('binshops_field_categories');
+    }
+}

--- a/migrations/2021_07_30_093700_create_binshops_fields_categories_table.php
+++ b/migrations/2021_07_30_093700_create_binshops_fields_categories_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreateBinshopFieldsCategoriesTable extends Migration
+class CreateBinshopsFieldsCategoriesTable extends Migration
 {
     /**
      * Run the migrations.

--- a/src/BinshopsBlogServiceProvider.php
+++ b/src/BinshopsBlogServiceProvider.php
@@ -38,6 +38,9 @@ class BinshopsBlogServiceProvider extends ServiceProvider
         }
 
         foreach ([
+                     '2021_07_30_093700_create_binshops_fields_categories_table.php',
+                     '2021_07_30_093600_create_binshops_fields_values_table.php',
+                     '2021_07_30_093500_create_binshops_fields_table.php',
                      '2020_10_16_005400_create_binshops_categories_table.php',
                      '2020_10_16_005425_create_binshops_category_translations_table.php',
                      '2020_10_16_010039_create_binshops_posts_table.php',

--- a/src/Controllers/BinshopsAdminController.php
+++ b/src/Controllers/BinshopsAdminController.php
@@ -14,6 +14,7 @@ use BinshopsBlog\Middleware\LoadLanguage;
 use BinshopsBlog\Middleware\PackageSetup;
 use BinshopsBlog\Middleware\UserCanManageBlogPosts;
 use BinshopsBlog\Models\BinshopsCategoryTranslation;
+use BinshopsBlog\Models\BinshopsField;
 use BinshopsBlog\Models\BinshopsLanguage;
 use BinshopsBlog\Models\BinshopsPost;
 use BinshopsBlog\Models\BinshopsPostTranslation;
@@ -83,7 +84,8 @@ class BinshopsAdminController extends Controller
             'selected_lang' => $language_id,
             'post' => $new_post,
             'post_translation' => new \BinshopsBlog\Models\BinshopsPostTranslation(),
-            'post_id' => -1
+            'post_id' => -1,
+            'fields' => BinshopsField::all()
         ]);
     }
 
@@ -259,7 +261,8 @@ class BinshopsAdminController extends Controller
             'selected_lang' => $language_id,
             'selected_locale' => BinshopsLanguage::where('id', $language_id)->first()->locale,
             'post' => $post,
-            'post_translation' => $post_translation
+            'post_translation' => $post_translation,
+            'fields' => BinshopsField::all()
         ]);
     }
 
@@ -291,7 +294,8 @@ class BinshopsAdminController extends Controller
             'selected_lang' => $request['selected_lang'],
             'selected_locale' => BinshopsLanguage::where('id', $request['selected_lang'])->first()->locale,
             'post' => $post,
-            'post_translation' => $post_translation
+            'post_translation' => $post_translation,
+            'fields' => BinshopsField::all()
         ]);
     }
 

--- a/src/Controllers/BinshopsAdminController.php
+++ b/src/Controllers/BinshopsAdminController.php
@@ -141,7 +141,7 @@ class BinshopsAdminController extends Controller
 
             DB::beginTransaction();
             try {
-                $new_blog_post->loadFields($request->post('category'));
+                $new_blog_post->loadFields($request->categories());
                 $new_blog_post->saveOrFail();
                 $new_blog_post->updateFieldValues($request->post());
 
@@ -212,7 +212,7 @@ class BinshopsAdminController extends Controller
 
                 DB::beginTransaction();
                 try {
-                    $new_blog_post->loadFields($request->post('category'));
+                    $new_blog_post->loadFields($request->categories());
                     $new_blog_post->saveOrFail();
                     $new_blog_post->updateFieldValues($request->post());
 
@@ -366,7 +366,7 @@ class BinshopsAdminController extends Controller
 
             DB::beginTransaction();
             try {
-                $new_blog_post->loadFields($request->post('category'));
+                $new_blog_post->loadFields($request->categories());
                 $new_blog_post->saveOrFail();
                 $new_blog_post->updateFieldValues($request->post());
 

--- a/src/Controllers/BinshopsAdminController.php
+++ b/src/Controllers/BinshopsAdminController.php
@@ -15,6 +15,7 @@ use BinshopsBlog\Middleware\PackageSetup;
 use BinshopsBlog\Middleware\UserCanManageBlogPosts;
 use BinshopsBlog\Models\BinshopsCategoryTranslation;
 use BinshopsBlog\Models\BinshopsField;
+use BinshopsBlog\Models\BinshopsFieldValue;
 use BinshopsBlog\Models\BinshopsLanguage;
 use BinshopsBlog\Models\BinshopsPost;
 use BinshopsBlog\Models\BinshopsPostTranslation;
@@ -125,9 +126,13 @@ class BinshopsAdminController extends Controller
         if ($post_exists){
             Helpers::flash_message("Post already exists - try to change the slug for this language");
         }else {
+
             $new_blog_post->is_published = $request['is_published'];
             $new_blog_post->user_id = \Auth::user()->id;
             $new_blog_post->save();
+
+            $new_blog_post->loadFields();
+            $new_blog_post->updateFieldValues($request->post());
 
             $translation->title = $request['title'];
             $translation->subtitle = $request['subtitle'];
@@ -186,6 +191,9 @@ class BinshopsAdminController extends Controller
                 $new_blog_post->is_published = $request['is_published'];
                 $new_blog_post->user_id = \Auth::user()->id;
                 $new_blog_post->save();
+
+                $new_blog_post->loadFields();
+                $new_blog_post->updateFieldValues($request->post());
 
                 $translation->title = $request['title'];
                 $translation->subtitle = $request['subtitle'];
@@ -330,6 +338,9 @@ class BinshopsAdminController extends Controller
             $new_blog_post->user_id = \Auth::user()->id;
             $new_blog_post->save();
 
+            $new_blog_post->loadFields();
+            $new_blog_post->updateFieldValues($request->post());
+
             $translation->title = $request['title'];
             $translation->subtitle = $request['subtitle'];
             $translation->short_description = $request['short_description'];
@@ -401,6 +412,8 @@ class BinshopsAdminController extends Controller
     public function destroy_post(DeleteBinshopsBlogPostRequest $request, $blogPostId)
     {
         $post = BinshopsPost::findOrFail($blogPostId);
+
+        BinshopsFieldValue::where('post_id',  $blogPostId)->delete();
         //archive deleted post
 
         $post->delete();

--- a/src/Controllers/BinshopsAdminController.php
+++ b/src/Controllers/BinshopsAdminController.php
@@ -129,8 +129,6 @@ class BinshopsAdminController extends Controller
         } else {
             $new_blog_post->is_published = $request['is_published'];
             $new_blog_post->user_id = \Auth::user()->id;
-            $new_blog_post->id = $new_blog_post->getNextId();
-
             $translation->title = $request['title'];
             $translation->subtitle = $request['subtitle'];
             $translation->short_description = $request['short_description'];
@@ -139,21 +137,18 @@ class BinshopsAdminController extends Controller
             $translation->meta_desc = $request['meta_desc'];
             $translation->slug = $request['slug'];
             $translation->use_view_file = $request['use_view_file'];
-
             $translation->lang_id = $request['lang_id'];
-            $translation->post_id = $new_blog_post->id;
-
-            $this->processUploadedImages($request, $translation);
-            $translation->save();
 
             DB::beginTransaction();
             try {
-                $new_blog_post->loadFields();
+                $new_blog_post->loadFields($request->post('category'));
+                $new_blog_post->saveOrFail();
                 $new_blog_post->updateFieldValues($request->post());
-                $new_blog_post->save();
 
                 $this->processUploadedImages($request, $translation);
-                $translation->save();
+
+                $translation->post_id = $new_blog_post->id;
+                $translation->saveOrFail();
 
                 $new_blog_post->categories()->sync($request->categories());
                 Helpers::flash_message("Post Updated");
@@ -204,7 +199,6 @@ class BinshopsAdminController extends Controller
             } else {
                 $new_blog_post->is_published = $request['is_published'];
                 $new_blog_post->user_id = \Auth::user()->id;
-                $new_blog_post->id = $new_blog_post->getNextId();
 
                 $translation->title = $request['title'];
                 $translation->subtitle = $request['subtitle'];
@@ -214,18 +208,17 @@ class BinshopsAdminController extends Controller
                 $translation->meta_desc = $request['meta_desc'];
                 $translation->slug = $request['slug'];
                 $translation->use_view_file = $request['use_view_file'];
-
                 $translation->lang_id = $request['lang_id'];
-                $translation->post_id = $new_blog_post->id;
 
                 DB::beginTransaction();
                 try {
-                    $new_blog_post->loadFields();
+                    $new_blog_post->loadFields($request->post('category'));
+                    $new_blog_post->saveOrFail();
                     $new_blog_post->updateFieldValues($request->post());
-                    $new_blog_post->save();
 
                     $this->processUploadedImages($request, $translation);
-                    $translation->save();
+                    $translation->post_id = $new_blog_post->id;
+                    $translation->saveOrFail();
 
                     $new_blog_post->categories()->sync($request->categories());
                     Helpers::flash_message("Post Updated");
@@ -369,18 +362,18 @@ class BinshopsAdminController extends Controller
             $translation->meta_desc = $request['meta_desc'];
             $translation->slug = $request['slug'];
             $translation->use_view_file = $request['use_view_file'];
-
             $translation->lang_id = $request['lang_id'];
-            $translation->post_id = $new_blog_post->id;
 
             DB::beginTransaction();
             try {
-                $new_blog_post->loadFields();
+                $new_blog_post->loadFields($request->post('category'));
+                $new_blog_post->saveOrFail();
                 $new_blog_post->updateFieldValues($request->post());
-                $new_blog_post->save();
 
                 $this->processUploadedImages($request, $translation);
-                $translation->save();
+
+                $translation->post_id = $new_blog_post->id;
+                $translation->saveOrFail();
 
                 $new_blog_post->categories()->sync($request->categories());
                 Helpers::flash_message("Post Updated");

--- a/src/Controllers/BinshopsFieldAdminController.php
+++ b/src/Controllers/BinshopsFieldAdminController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace BinshopsBlog\Controllers;
+
+use App\Http\Controllers\Controller;
+use BinshopsBlog\Events\FieldyAdded;
+use Illuminate\Http\Request;
+use BinshopsBlog\Events\FieldAdded;
+use BinshopsBlog\Events\FieldWillBeDeleted;
+use BinshopsBlog\Helpers;
+use BinshopsBlog\Middleware\LoadLanguage;
+use BinshopsBlog\Middleware\UserCanManageBlogPosts;
+use BinshopsBlog\Models\BinshopsCategoryTranslation;
+use BinshopsBlog\Models\BinshopsField;
+use BinshopsBlog\Requests\BaseBinshopsBlogFieldRequest;
+
+/**
+ * Class BinshopsFielddminController
+ * @package BinshopsBlog\Controllers
+ */
+class BinshopsFieldAdminController extends Controller
+{
+    /**
+     * BinshopsCategoryAdminController constructor.
+     */
+    public function __construct()
+    {
+        $this->middleware(UserCanManageBlogPosts::class);
+        $this->middleware(LoadLanguage::class);
+
+    }
+
+    /**
+     * Show list of fields
+     *
+     * @return mixed
+     */
+    public function index(Request $request)
+    {
+        $language_id = $request->get('language_id');
+        $fields = BinshopsField::orderBy("label")->paginate(25);
+        return view("binshopsblog_admin::fields.index",[
+            'fields' => $fields,
+            'language_id' => $language_id
+        ]);
+    }
+
+    /**
+     * Show the form for creating new field
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function create_field(Request $request)
+    {
+        $language_id = $request->get('language_id');
+        $categoriesTrans = BinshopsCategoryTranslation::where("lang_id",$language_id)->limit(1000)->get();
+
+        return view("binshopsblog_admin::fields.form",[
+            'field' => new \BinshopsBlog\Models\BinshopsField(),
+            'categoriesTrans' => $categoriesTrans
+        ]);
+    }
+
+    /**
+     * Show the edit form for field
+     * @param $fieldId
+     * @return mixed
+     */
+    public function edit_field($fieldId, Request $request){
+        $language_id = $request->get('language_id');
+        $categoriesTrans = BinshopsCategoryTranslation::where("lang_id",$language_id)->limit(1000)->get();
+
+        $field = BinshopsField::where(
+            [
+                ['id', '=', $fieldId]
+            ]
+        )->first();
+
+        return view("binshopsblog_admin::fields.form",[
+            'field' => $field,
+            'categoriesTrans' => $categoriesTrans
+        ]);
+    }
+
+    /**
+     * Store a new field
+     *
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
+     *
+     * This controller is totally REST controller
+     */
+    public function store_field(BaseBinshopsBlogFieldRequest $request)
+    {
+        $new_field = BinshopsField::create([
+            'label' => $request->post('label'),
+            'type' => $request->post('type'),
+            'validation' => $request->post('validation')
+        ]);
+
+        $new_field->categories()->sync($request->categories());
+        event(new FieldAdded($new_field));
+        Helpers::flash_message("Saved new field");
+        return response()->json([
+            'code' => 200,
+            'message' => "field successfully added"
+        ]);
+    }
+
+    /**
+     * Delete the field
+     *
+     * @param $request
+     * @param $categoryId
+     * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
+     */
+    public function destroy_field($fieldId)
+    {
+        $field = BinshopsField::findOrFail($fieldId);
+
+        if($field->values()->exists()) {
+            Helpers::flash_message("This field could not be deleted, blog posts with values for this field exists.");
+            return redirect(route('binshopsblog.admin.fields.index'));
+        }
+        $field->categories()->detach();
+
+        event(new FieldWillBeDeleted($field));
+        $field->delete();
+
+        Helpers::flash_message("Field successfully deleted!");
+        return redirect( route('binshopsblog.admin.fields.index') );
+    }
+
+}

--- a/src/Controllers/BinshopsFieldAdminController.php
+++ b/src/Controllers/BinshopsFieldAdminController.php
@@ -27,7 +27,6 @@ class BinshopsFieldAdminController extends Controller
     {
         $this->middleware(UserCanManageBlogPosts::class);
         $this->middleware(LoadLanguage::class);
-
     }
 
     /**
@@ -39,7 +38,7 @@ class BinshopsFieldAdminController extends Controller
     {
         $language_id = $request->get('language_id');
         $fields = BinshopsField::orderBy("label")->paginate(25);
-        return view("binshopsblog_admin::fields.index",[
+        return view("binshopsblog_admin::fields.index", [
             'fields' => $fields,
             'language_id' => $language_id
         ]);
@@ -52,9 +51,9 @@ class BinshopsFieldAdminController extends Controller
     public function create_field(Request $request)
     {
         $language_id = $request->get('language_id');
-        $categoriesTrans = BinshopsCategoryTranslation::where("lang_id",$language_id)->limit(1000)->get();
+        $categoriesTrans = BinshopsCategoryTranslation::where("lang_id", $language_id)->limit(1000)->get();
 
-        return view("binshopsblog_admin::fields.form",[
+        return view("binshopsblog_admin::fields.form", [
             'field' => new \BinshopsBlog\Models\BinshopsField(),
             'categoriesTrans' => $categoriesTrans
         ]);
@@ -65,9 +64,10 @@ class BinshopsFieldAdminController extends Controller
      * @param $fieldId
      * @return mixed
      */
-    public function edit_field($fieldId, Request $request){
+    public function edit_field($fieldId, Request $request)
+    {
         $language_id = $request->get('language_id');
-        $categoriesTrans = BinshopsCategoryTranslation::where("lang_id",$language_id)->limit(1000)->get();
+        $categoriesTrans = BinshopsCategoryTranslation::where("lang_id", $language_id)->limit(1000)->get();
 
         $field = BinshopsField::where(
             [
@@ -75,7 +75,7 @@ class BinshopsFieldAdminController extends Controller
             ]
         )->first();
 
-        return view("binshopsblog_admin::fields.form",[
+        return view("binshopsblog_admin::fields.form", [
             'field' => $field,
             'categoriesTrans' => $categoriesTrans
         ]);
@@ -90,19 +90,21 @@ class BinshopsFieldAdminController extends Controller
      */
     public function store_field(BaseBinshopsBlogFieldRequest $request)
     {
-        $new_field = BinshopsField::create([
-            'label' => $request->post('label'),
-            'type' => $request->post('type'),
-            'validation' => $request->post('validation')
-        ]);
+        $new_field = BinshopsField::updateOrCreate(
+            ['id' => $request->post('id')],
+            [
+                'name' => $request->post('name'),
+                'label' => $request->post('label'),
+                'help' => $request->post('help'),
+                'type' => $request->post('type'),
+                'validation' => $request->post('validation')
+            ]);
 
         $new_field->categories()->sync($request->categories());
         event(new FieldAdded($new_field));
         Helpers::flash_message("Saved new field");
-        return response()->json([
-            'code' => 200,
-            'message' => "field successfully added"
-        ]);
+
+        return redirect( route('binshopsblog.admin.fields.index') );
     }
 
     /**
@@ -116,7 +118,7 @@ class BinshopsFieldAdminController extends Controller
     {
         $field = BinshopsField::findOrFail($fieldId);
 
-        if($field->values()->exists()) {
+        if ($field->values()->exists()) {
             Helpers::flash_message("This field could not be deleted, blog posts with values for this field exists.");
             return redirect(route('binshopsblog.admin.fields.index'));
         }
@@ -126,7 +128,6 @@ class BinshopsFieldAdminController extends Controller
         $field->delete();
 
         Helpers::flash_message("Field successfully deleted!");
-        return redirect( route('binshopsblog.admin.fields.index') );
+        return redirect(route('binshopsblog.admin.fields.index'));
     }
-
 }

--- a/src/Controllers/BinshopsFieldAdminController.php
+++ b/src/Controllers/BinshopsFieldAdminController.php
@@ -12,7 +12,7 @@ use BinshopsBlog\Middleware\LoadLanguage;
 use BinshopsBlog\Middleware\UserCanManageBlogPosts;
 use BinshopsBlog\Models\BinshopsCategoryTranslation;
 use BinshopsBlog\Models\BinshopsField;
-use BinshopsBlog\Requests\BaseBinshopsBlogFieldRequest;
+use BinshopsBlog\Requests\BaseBinshopsFieldRequest;
 
 /**
  * Class BinshopsFielddminController
@@ -88,7 +88,7 @@ class BinshopsFieldAdminController extends Controller
      *
      * This controller is totally REST controller
      */
-    public function store_field(BaseBinshopsBlogFieldRequest $request)
+    public function store_field(BaseBinshopsFieldRequest $request)
     {
         $new_field = BinshopsField::updateOrCreate(
             ['id' => $request->post('id')],

--- a/src/Controllers/BinshopsReaderController.php
+++ b/src/Controllers/BinshopsReaderController.php
@@ -3,6 +3,7 @@
 namespace BinshopsBlog\Controllers;
 
 use App\Http\Controllers\Controller;
+use BinshopsBlog\Models\BinshopsFieldValue;
 use Carbon\Carbon;
 use BinshopsBlog\Laravel\Fulltext\Search;
 use BinshopsBlog\Models\BinshopsCategoryTranslation;
@@ -144,6 +145,7 @@ class BinshopsReaderController extends Controller
             ["slug", "=", $blogPostSlug],
             ['lang_id', "=" , $request->get("lang_id")]
         ])->firstOrFail();
+        $fieldValues = BinshopsFieldValue::where('post_id', $blog_post->post_id)->get();
 
         if ($captcha = $this->getCaptchaObject()) {
             $captcha->runCaptchaBeforeShowingPosts($request, $blog_post);
@@ -156,6 +158,7 @@ class BinshopsReaderController extends Controller
                 ->with("user")
                 ->get(),
             'captcha' => $captcha,
+            'fieldvalues' => $fieldValues
         ]);
     }
 

--- a/src/Events/FieldAdded.php
+++ b/src/Events/FieldAdded.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BinshopsBlog\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use BinshopsBlog\Models\BinshopsField;
+
+/**
+ * Class CategoryAdded
+ * @package BinshopsBlog\Events
+ */
+class FieldAdded
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /** @var  BinshopsField */
+    public $binshopsField;
+
+    /**
+     * CategoryAdded constructor.
+     * @param BinshopsField $binshopsField
+     */
+    public function __construct(BinshopsField $binshopsField)
+    {
+        $this->binshopsField = $binshopsField;
+    }
+
+}

--- a/src/Events/FieldWillBeDeleted.php
+++ b/src/Events/FieldWillBeDeleted.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace BinshopsBlog\Events;
+
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use BinshopsBlog\Models\BinshopsField;
+
+/**
+ * Class FieldWillBeDeleted
+ * @package BinshopsBlog\Events
+ */
+class FieldWillBeDeleted
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /** @var  BinshopsField */
+    public $binshopsBlogField;
+
+    /**
+     * FieldWillBeDeleted constructor.
+     * @param BinshopsField $binshopsBlogField
+     */
+    public function __construct(BinshopsField $binshopsBlogField)
+    {
+        $this->binshopsBlogField = $binshopsBlogField;
+    }
+
+}

--- a/src/Models/BinshopsField.php
+++ b/src/Models/BinshopsField.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace BinshopsBlog\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class BinshopsPost
+ * @package BinshopsBlog\Models
+ */
+class BinshopsField extends Model
+{
+    /**
+     * @var array
+     */
+    public $casts = [
+
+    ];
+
+    /**
+     * @var array
+     */
+    public $dates = [
+
+    ];
+
+    /**
+     * @var array
+     */
+    public $fillable = [
+        'label',
+        'type',
+        'validation',
+    ];
+
+    /**
+     *
+     */
+    public function fieldTypes()
+    {
+       return [
+           1 => 'text',
+           2 => 'textarea',
+           3 => 'number',
+           4 => 'date',
+           5 => 'url'
+       ];
+    }
+
+    public function typeName()
+    {
+        return $this->fieldTypes()[$this->type];
+    }
+
+    /**
+     * The associated categories for this blog post
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function categories()
+    {
+        return $this->belongsToMany(BinshopsCategory::class, 'binshops_field_categories','field_id','category_id');
+    }
+
+    /**
+     * The associated categories for this blog post
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function values()
+    {
+        return $this->hasMany(BinshopsFieldValue::class, 'field_id');
+    }
+
+
+    /**
+     * Returns the URL for an admin user to edit this category
+     * @return string
+     */
+    public function edit_url()
+    {
+        return route("binshopsblog.admin.fields.edit_field", $this->id);
+    }
+
+    public function getClasses()
+    {
+        if(!$this->categories()->exists()) {
+            return 'no_categories';
+        }
+        $classes = '';
+        foreach($this->categories as $category){
+            $classes .= 'field_category_' . $category->id . ' ';
+        }
+        return $classes;
+    }
+}

--- a/src/Models/BinshopsField.php
+++ b/src/Models/BinshopsField.php
@@ -28,7 +28,9 @@ class BinshopsField extends Model
      * @var array
      */
     public $fillable = [
+        'name',
         'label',
+        'help',
         'type',
         'validation',
     ];

--- a/src/Models/BinshopsField.php
+++ b/src/Models/BinshopsField.php
@@ -2,10 +2,13 @@
 
 namespace BinshopsBlog\Models;
 
+use BinshopsBlog\Helpers;
 use Illuminate\Database\Eloquent\Model;
+use Validator;
 
 /**
  * Class BinshopsPost
+ * @property mixed validation
  * @package BinshopsBlog\Models
  */
 class BinshopsField extends Model
@@ -36,22 +39,36 @@ class BinshopsField extends Model
     ];
 
     /**
-     *
+     * @return string[]
      */
     public function fieldTypes()
     {
-       return [
+        return [
            1 => 'text',
            2 => 'textarea',
            3 => 'number',
            4 => 'date',
            5 => 'url'
-       ];
+        ];
     }
 
+    /**
+     * @return string
+     */
     public function typeName()
     {
         return $this->fieldTypes()[$this->type];
+    }
+
+    public function defaultValidation()
+    {
+        return [
+            'text' => 'string|max:255',
+            'textarea' => 'string|max:510',
+            'number' => 'numeric',
+            'date' => 'date',
+            'url' => 'url'
+        ];
     }
 
     /**
@@ -61,7 +78,7 @@ class BinshopsField extends Model
      */
     public function categories()
     {
-        return $this->belongsToMany(BinshopsCategory::class, 'binshops_field_categories','field_id','category_id');
+        return $this->belongsToMany(BinshopsCategory::class, 'binshops_field_categories', 'field_id', 'category_id');
     }
 
     /**
@@ -74,7 +91,6 @@ class BinshopsField extends Model
         return $this->hasMany(BinshopsFieldValue::class, 'field_id');
     }
 
-
     /**
      * Returns the URL for an admin user to edit this category
      * @return string
@@ -86,11 +102,11 @@ class BinshopsField extends Model
 
     public function getClasses()
     {
-        if(!$this->categories()->exists()) {
+        if (!$this->categories()->exists()) {
             return 'no_categories';
         }
         $classes = '';
-        foreach($this->categories as $category){
+        foreach ($this->categories as $category) {
             $classes .= 'field_category_' . $category->id . ' ';
         }
         return $classes;

--- a/src/Models/BinshopsFieldCategory.php
+++ b/src/Models/BinshopsFieldCategory.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BinshopsBlog\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class BinshopsPost
+ * @package BinshopsBlog\Models
+ */
+class BinshopsFieldCategory extends Model
+{
+    /**
+     * @var array
+     */
+    public $casts = [
+
+    ];
+
+    /**
+     * @var array
+     */
+    public $dates = [
+
+    ];
+
+    /**
+     * @var array
+     */
+    public $fillable = [
+    ];
+
+    /**
+     * The associated BinshopsCategory
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function category()
+    {
+        return $this->belongsTo(BinshopsPost::class,"category_id");
+    }
+
+    /**
+     * The associated BinshopsField
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function field()
+    {
+        return $this->belongsTo(BinshopsField::class,"field_id");
+    }
+}

--- a/src/Models/BinshopsFieldValue.php
+++ b/src/Models/BinshopsFieldValue.php
@@ -28,6 +28,8 @@ class BinshopsFieldValue extends Model
      * @var array
      */
     public $fillable = [
+        'field_id',
+        'post_id',
         'value',
     ];
 

--- a/src/Models/BinshopsFieldValue.php
+++ b/src/Models/BinshopsFieldValue.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace BinshopsBlog\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Class BinshopsPost
+ * @package BinshopsBlog\Models
+ */
+class BinshopsFieldValue extends Model
+{
+    /**
+     * @var array
+     */
+    public $casts = [
+
+    ];
+
+    /**
+     * @var array
+     */
+    public $dates = [
+
+    ];
+
+    /**
+     * @var array
+     */
+    public $fillable = [
+        'value',
+    ];
+
+    /**
+     * The associated BinshopsPost
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function post()
+    {
+        return $this->belongsTo(BinshopsPost::class,"post_id");
+    }
+
+    /**
+     * The associated BinshopsField
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function field()
+    {
+        return $this->belongsTo(BinshopsField::class,"field_id");
+    }
+}

--- a/src/Models/BinshopsPost.php
+++ b/src/Models/BinshopsPost.php
@@ -132,10 +132,8 @@ class BinshopsPost extends Model
         return;
     }
 
-    public function loadFields()
+    public function loadFields($categories)
     {
-        // Get all the categories which are attached to this post
-        $categories = $this->categories()->pluck('category_id')->toArray();
         $this->fields = $this->fieldsAvailable($categories);
     }
 
@@ -181,11 +179,5 @@ class BinshopsPost extends Model
                 ['value' => $fieldsValues[$field->name]]
             );
         }
-    }
-
-    public function getNextId()
-    {
-        $statement = DB::select("show table status like 'binshops_posts'");
-        return $statement[0]->Auto_increment;
     }
 }

--- a/src/Models/BinshopsPost.php
+++ b/src/Models/BinshopsPost.php
@@ -157,42 +157,11 @@ class BinshopsPost extends Model
         return $fieldsNocategorie->merge($fieldsOverlappingCategories);
     }
 
-    public function validateFieldValues($fieldsValues)
-    {
-        $validated = true;
-        foreach ($this->fields as $field) {
-            //First some default validation
-            $validation = Validator::make(
-                [$field->type => $fieldsValues[$field->name]],
-                $field->defaultValidation()
-            );
-            if (!$validation->passes()) {
-                Helpers::flash_message($validation->messages());
-                $validated = false;
-            }
-
-            // Custom validation
-            $validation = Validator::make(
-                [$field->name => $fieldsValues[$field->name]],
-                [$field->name => $field->validation]
-            );
-
-            if (!$validation->passes()) {
-                Helpers::flash_message($validation->messages());
-                $validated = false;
-            }
-        }
-        return $validated;
-    }
-
     /**
      * @param $fieldsValues
      */
     public function updateFieldValues($fieldsValues)
     {
-        if (!$this->validateFieldValues($fieldsValues)) {
-            return;
-        }
         foreach ($this->fields as $field) {
             if ($fieldsValues[$field->name] == null) {
                 // Field is empty, therefore delete completely

--- a/src/Requests/BaseBinshopsBlogFieldRequest.php
+++ b/src/Requests/BaseBinshopsBlogFieldRequest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BinshopsBlog\Requests;
+
+use BinshopsBlog\Requests\Traits\HasCategoriesTrait;
+
+class BaseBinshopsBlogFieldRequest extends BaseRequest
+{
+    use HasCategoriesTrait;
+
+    /**
+     * Shared rules for fields
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'label' => ['required', 'string', 'min:1', 'max:200'],
+            'type' => ['required', 'integer'],
+            'validation' => ['nullable', 'string', 'min:1', 'max:5000'],
+            'categories' => ['nullable', 'array'],
+        ];
+    }
+}

--- a/src/Requests/BaseBinshopsBlogFieldRequest.php
+++ b/src/Requests/BaseBinshopsBlogFieldRequest.php
@@ -15,7 +15,9 @@ class BaseBinshopsBlogFieldRequest extends BaseRequest
     public function rules()
     {
         return [
+            'name' => ['alpha_num', 'unique:binshops_fields,name,'. $this->id, 'string', 'min:1', 'max:200'],
             'label' => ['required', 'string', 'min:1', 'max:200'],
+            'help' => ['required', 'string', 'min:1', 'max:200'],
             'type' => ['required', 'integer'],
             'validation' => ['nullable', 'string', 'min:1', 'max:5000'],
             'categories' => ['nullable', 'array'],

--- a/src/Requests/BaseBinshopsBlogPostRequest.php
+++ b/src/Requests/BaseBinshopsBlogPostRequest.php
@@ -2,6 +2,7 @@
 
 namespace BinshopsBlog\Requests;
 
+use BinshopsBlog\Models\BinshopsPost;
 use Carbon\Carbon;
 
 abstract class BaseBinshopsBlogPostRequest extends BaseRequest
@@ -73,8 +74,24 @@ abstract class BaseBinshopsBlogPostRequest extends BaseRequest
                 $return[$size] = $show_error_if_has_value;
             }
         }
-        return $return;
+
+        $fieldRules = self::baseFieldValueRules();
+
+        return array_merge($return, $fieldRules);
     }
 
-
+    public function baseFieldValueRules()
+    {
+        $post = new BinshopsPost;
+        // Get the fields that are available for the given categories.
+        $fields = $post->fieldsAvailable($this->post('category'))->pluck('name')->toArray();
+        $fieldValueRules = BaseBinshopsFieldValueRequest::baseFieldValueRules();
+        foreach ($fieldValueRules as $key => $rule) {
+            // Fields that are not available for given categories are not checked.
+            if (!in_array($key, $fields)) {
+                unset($fieldValueRules[$key]);
+            }
+        }
+        return $fieldValueRules;
+    }
 }

--- a/src/Requests/BaseBinshopsBlogPostRequest.php
+++ b/src/Requests/BaseBinshopsBlogPostRequest.php
@@ -3,10 +3,12 @@
 namespace BinshopsBlog\Requests;
 
 use BinshopsBlog\Models\BinshopsPost;
+use BinshopsBlog\Requests\Traits\HasCategoriesTrait;
 use Carbon\Carbon;
 
 abstract class BaseBinshopsBlogPostRequest extends BaseRequest
 {
+    use HasCategoriesTrait;
 
     /**
      * Shared rules for blog posts
@@ -84,7 +86,7 @@ abstract class BaseBinshopsBlogPostRequest extends BaseRequest
     {
         $post = new BinshopsPost;
         // Get the fields that are available for the given categories.
-        $fields = $post->fieldsAvailable($this->post('category'))->pluck('name')->toArray();
+        $fields = $post->fieldsAvailable($this->categories())->pluck('name')->toArray();
         $fieldValueRules = BaseBinshopsFieldValueRequest::baseFieldValueRules();
         foreach ($fieldValueRules as $key => $rule) {
             // Fields that are not available for given categories are not checked.

--- a/src/Requests/BaseBinshopsFieldRequest.php
+++ b/src/Requests/BaseBinshopsFieldRequest.php
@@ -4,7 +4,7 @@ namespace BinshopsBlog\Requests;
 
 use BinshopsBlog\Requests\Traits\HasCategoriesTrait;
 
-class BaseBinshopsBlogFieldRequest extends BaseRequest
+class BaseBinshopsFieldRequest extends BaseRequest
 {
     use HasCategoriesTrait;
 

--- a/src/Requests/BaseBinshopsFieldValueRequest.php
+++ b/src/Requests/BaseBinshopsFieldValueRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace BinshopsBlog\Requests;
+
+use BinshopsBlog\Models\BinshopsField;
+use BinshopsBlog\Requests\Traits\HasCategoriesTrait;
+
+abstract class BaseBinshopsFieldValueRequest extends BaseRequest
+{
+
+    /**
+     * @return string[]
+     */
+    public static function typesDefaultRules()
+    {
+        return [
+            'text' => 'string',
+            'textarea' => 'string',
+            'number' => 'numeric',
+            'date' => 'date',
+            'url' => 'url'
+        ];
+    }
+
+    /**
+     * Shared rules for fields
+     * @return array
+     */
+    public static function baseFieldValueRules()
+    {
+        $fields = BinshopsField::all();
+        $rules = [];
+        foreach ($fields as $field) {
+            $rules[$field->name] = self::typesDefaultRules()[$field->typeName()];
+            if ($field->validation !== null) {
+                $rules[$field->name] .= '|' . $field->validation;
+            }
+
+        }
+
+        return $rules;
+    }
+}

--- a/src/Requests/BaseBinshopsFieldValueRequest.php
+++ b/src/Requests/BaseBinshopsFieldValueRequest.php
@@ -36,6 +36,9 @@ abstract class BaseBinshopsFieldValueRequest extends BaseRequest
                 $rules[$field->name] .= '|' . $field->validation;
             }
 
+            if ($field->validation == null) {
+                $rules[$field->name] .= '|nullable';
+            }
         }
 
         return $rules;

--- a/src/Views/binshopsblog/partials/full_post_details.blade.php
+++ b/src/Views/binshopsblog/partials/full_post_details.blade.php
@@ -6,7 +6,6 @@
 <h1 class='blog_title'>{{$post->title}}</h1>
 <h5 class='blog_subtitle'>{{$post->subtitle}}</h5>
 
-
 <?=$post->image_tag("medium", false, 'd-block mx-auto'); ?>
 
 <p class="blog_body_content">
@@ -20,6 +19,13 @@
     {{--   {{ $post->post_body }}          // for safe escaping --}}
     {{--@endif--}}
 </p>
+@foreach($fieldvalues as $value)
+    <p>
+        <b>{!! $value->field->label !!}: </b>
+        {!! $value->value !!}
+    </p>
+@endforeach
+
 
 <hr/>
 

--- a/src/Views/binshopsblog_admin/fields/form.blade.php
+++ b/src/Views/binshopsblog_admin/fields/form.blade.php
@@ -1,0 +1,87 @@
+@extends("binshopsblog_admin::layouts.admin_layout")
+@section("content")
+
+    <h5>Admin - Add Field</h5>
+    <form method='post' name='fieldForm' id='fieldForm' action='{{route("binshopsblog.admin.fields.create_field")}}'  enctype="multipart/form-data" >
+
+        @csrf
+        <div class="form-group">
+            <label for="label">Label</label>
+
+            <input type="text"
+                   class="form-control"
+                   id="label"
+{{--                   oninput="populate_slug_field();"--}}
+                   required
+                   aria-describedby="field_label_help"
+                   name='label'
+                   value="{{old("label", $field->label)}}"
+            >
+
+            <small id="field_label_help" class="form-text text-muted">Label name of field</small>
+        </div>
+        <div class="form-group">
+            <label for="type">Type</label>
+            <select name="type">
+                @foreach($field->fieldTypes() as $key => $fieldtype)
+{{--                    <option value="24" selected>Product 1</option>--}}
+                    <option value="{{$key}}">{{$fieldtype}}</option>
+                @endforeach
+            </select>
+            <small id="field_type_help" class="form-text text-muted">
+                Letters, numbers, dash only. The slug
+            </small>
+        </div>
+
+        <div class="form-group">
+            <label for="validation">Field Validation</label>
+            <textarea name='validation'
+                      class='form-control'
+                      id='validation'>{{old("field_validation",$field->validation)}}</textarea>
+        </div>
+
+        <div class='bg-white pt-4 px-4 pb-0 my-2 mb-4 rounded border'>
+            <h4>Categories:</h4>
+            <div class='row'>
+
+                @forelse($categoriesTrans as $translation)
+                    <div class="form-check col-sm-6">
+                        <input class="" type="checkbox" value="1"
+                               @if(old("category.".$translation->category_id, $field->categories->contains($translation->category_id))) checked='checked'
+                               @endif name='category[{{$translation->category_id}}]' id="category_check{{$translation->category_id}}">
+                        <label class="form-check-label" for="category_check{{$translation->category_id}}">
+                            {{$translation->category_name}}
+                        </label>
+                    </div>
+                @empty
+                    <div class='col-md-12'>
+                        No categories
+                    </div>
+                @endforelse
+            </div>
+        </div>
+
+        <button type="button" class='btn btn-primary' id="submit-btn">Add new field</button>
+        <script>
+            $.ajaxSetup({
+                headers: {
+                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
+                }
+            });
+
+            $('#submit-btn').click(function (){
+                $.ajax({
+                    url: '{{route("binshopsblog.admin.fields.store_field")}}',
+                    type: "POST",
+                    data: $('#fieldForm').serialize(),
+                    success: function( response ) {
+                        {{--window.location.replace("{{route('binshopsblog.admin.fields.index')}}");--}}
+                    },
+                    error: function (responde) {
+                        alert('Oh dear');
+                    }
+                });
+            });
+        </script>
+    </form>
+@endsection

--- a/src/Views/binshopsblog_admin/fields/form.blade.php
+++ b/src/Views/binshopsblog_admin/fields/form.blade.php
@@ -2,29 +2,54 @@
 @section("content")
 
     <h5>Admin - Add Field</h5>
-    <form method='post' name='fieldForm' id='fieldForm' action='{{route("binshopsblog.admin.fields.create_field")}}'  enctype="multipart/form-data" >
+    <form method='post' name='fieldForm' id='fieldForm'
+          action='{{route("binshopsblog.admin.fields.store_field")}}'
+          enctype="multipart/form-data" >
 
         @csrf
+        <input type="hidden" name="id"  value="{{$field->id}}">
+        <div class="form-group">
+            <label for="name">Name</label>
+            <input type="text"
+                   class="form-control"
+                   id="name"
+                   required
+                   aria-describedby="field_name_help"
+                   name='name'
+                   value="{{old("name", $field->name)}}"
+            >
+
+            <small id="field_name_help" class="form-text text-muted">Name of field</small>
+        </div>
         <div class="form-group">
             <label for="label">Label</label>
-
             <input type="text"
                    class="form-control"
                    id="label"
-{{--                   oninput="populate_slug_field();"--}}
                    required
                    aria-describedby="field_label_help"
                    name='label'
                    value="{{old("label", $field->label)}}"
             >
-
             <small id="field_label_help" class="form-text text-muted">Label name of field</small>
+        </div>
+        <div class="form-group">
+            <label for="help">Help</label>
+            <input type="text"
+                   class="form-control"
+                   id="help"
+                   required
+                   aria-describedby="field_help_help"
+                   name='help'
+                   value="{{old("help", $field->help)}}"
+            >
+
+            <small id="field_help_help" class="form-text text-muted">Help text for field</small>
         </div>
         <div class="form-group">
             <label for="type">Type</label>
             <select name="type">
                 @foreach($field->fieldTypes() as $key => $fieldtype)
-{{--                    <option value="24" selected>Product 1</option>--}}
                     <option value="{{$key}}">{{$fieldtype}}</option>
                 @endforeach
             </select>
@@ -61,27 +86,6 @@
             </div>
         </div>
 
-        <button type="button" class='btn btn-primary' id="submit-btn">Add new field</button>
-        <script>
-            $.ajaxSetup({
-                headers: {
-                    'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')
-                }
-            });
-
-            $('#submit-btn').click(function (){
-                $.ajax({
-                    url: '{{route("binshopsblog.admin.fields.store_field")}}',
-                    type: "POST",
-                    data: $('#fieldForm').serialize(),
-                    success: function( response ) {
-                        {{--window.location.replace("{{route('binshopsblog.admin.fields.index')}}");--}}
-                    },
-                    error: function (responde) {
-                        alert('Oh dear');
-                    }
-                });
-            });
-        </script>
+        <input type='submit' name="submit_btn" class='btn btn-primary' value='Add new field' >
     </form>
 @endsection

--- a/src/Views/binshopsblog_admin/fields/form.blade.php
+++ b/src/Views/binshopsblog_admin/fields/form.blade.php
@@ -50,11 +50,15 @@
             <label for="type">Type</label>
             <select name="type">
                 @foreach($field->fieldTypes() as $key => $fieldtype)
+                    @if($field->type == $key)
+                        <option value="{{$key}}" selected>{{$fieldtype}}</option>
+                        @php continue; @endphp
+                    @endif
                     <option value="{{$key}}">{{$fieldtype}}</option>
                 @endforeach
             </select>
             <small id="field_type_help" class="form-text text-muted">
-                Letters, numbers, dash only. The slug
+                Field type, these type are have default validation
             </small>
         </div>
 
@@ -63,6 +67,10 @@
             <textarea name='validation'
                       class='form-control'
                       id='validation'>{{old("field_validation",$field->validation)}}</textarea>
+            <small id="field_validation_help" class="form-text text-muted">
+                Fields have default validation, but you can define extra validation. You have to do this
+                in laravel style, for example: 'required|min:2|max:20'.
+            </small>
         </div>
 
         <div class='bg-white pt-4 px-4 pb-0 my-2 mb-4 rounded border'>
@@ -84,6 +92,10 @@
                     </div>
                 @endforelse
             </div>
+            <small id="field_category_help" class="form-text text-muted">
+                You can select one or more categories, for this field. The field will only be displayed on posts which have
+                one or more matching categories. When no category is selected this field is displayed on all posts.
+            </small>
         </div>
 
         <input type='submit' name="submit_btn" class='btn btn-primary' value='Add new field' >

--- a/src/Views/binshopsblog_admin/fields/index.blade.php
+++ b/src/Views/binshopsblog_admin/fields/index.blade.php
@@ -1,0 +1,47 @@
+@extends("binshopsblog_admin::layouts.admin_layout")
+@section("content")
+
+    @forelse ($fields as $field)
+
+        <div class="card m-4">
+            <div class="card-body">
+
+
+                <h5 class='card-title'>{{$field->label}}</h5>
+
+                <dt class="">Categories</dt>
+                <dd class="">
+                    @if(count($field->categories))
+                        @foreach($field->categories as $category)
+                            <a class='btn btn-outline-secondary btn-sm m-1' href='{{$category->categoryTranslations->where('lang_id' , $language_id)->first()->edit_url()}}'>
+                                <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+
+                                {{$category->categoryTranslations->where('lang_id' , $language_id)->first()->category_name}}
+                            </a>
+                        @endforeach
+                    @else No Categories
+                    @endif
+
+                </dd>
+                <a href="{{$field->edit_url()}}" class="card-link btn btn-primary">Edit Field</a>
+                <form
+                        onsubmit="return confirm('Are you sure you want to delete this field?\n You cannot undo this action!');"
+                        method='post' action='{{route("binshopsblog.admin.fields.destroy_field", $field->id)}}' class='float-right'>
+                    @csrf
+                    @method("DELETE")
+                    <input type='submit' class='btn btn-danger btn-sm' value='Delete'/>
+                </form>
+            </div>
+        </div>
+
+
+    @empty
+    <div class='alert alert-danger'>None found, why don't you add one?</div>
+    @endforelse
+
+
+    <div class='text-center'>
+        {{$fields->appends( [] )->links()}}
+    </div>
+
+    @endsection

--- a/src/Views/binshopsblog_admin/fields/index.blade.php
+++ b/src/Views/binshopsblog_admin/fields/index.blade.php
@@ -2,25 +2,25 @@
 @section("content")
 
     @forelse ($fields as $field)
-
         <div class="card m-4">
             <div class="card-body">
-
-
                 <h5 class='card-title'>{{$field->label}}</h5>
-
+                <dd><b>Name: </b>{{$field->name}}</dd>
+                <dd><b>Type: </b>{{$field->typeName()}}</dd>
+                <dd><b>Help: </b>{{$field->help}}</dd>
+                <dd><b>Validation: </b>{{$field->validation}}</dd>
                 <dt class="">Categories</dt>
                 <dd class="">
-                    @if(count($field->categories))
-                        @foreach($field->categories as $category)
-                            <a class='btn btn-outline-secondary btn-sm m-1' href='{{$category->categoryTranslations->where('lang_id' , $language_id)->first()->edit_url()}}'>
-                                <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
+            @if(count($field->categories))
+                @foreach($field->categories as $category)
+                        <a class='btn btn-outline-secondary btn-sm m-1' href='{{$category->categoryTranslations->where('lang_id' , $language_id)->first()->edit_url()}}'>
+                <i class="fa fa-pencil-square-o" aria-hidden="true"></i>
 
-                                {{$category->categoryTranslations->where('lang_id' , $language_id)->first()->category_name}}
-                            </a>
-                        @endforeach
-                    @else No Categories
-                    @endif
+                {{$category->categoryTranslations->where('lang_id' , $language_id)->first()->category_name}}
+                </a>
+                @endforeach
+            @else No Categories, field is used on all posts.
+                @endif
 
                 </dd>
                 <a href="{{$field->edit_url()}}" class="card-link btn btn-primary">Edit Field</a>

--- a/src/Views/binshopsblog_admin/fields/partials/date.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/date.blade.php
@@ -1,0 +1,10 @@
+<div class="form-group">
+    <label for="{{$field->label}}">{{$field->label}}</label>
+    <input type="date"
+           class="form-control field_category {{$classes}}"
+           id="{{$field->label}}"
+           name="{{$field->label}}"
+           {{$classes == 'no_categories'?'':'disabled'}}
+           value="{{old($field->label, $value)}}"
+    >
+</div>

--- a/src/Views/binshopsblog_admin/fields/partials/date.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/date.blade.php
@@ -1,10 +1,10 @@
 <div class="form-group">
-    <label for="{{$field->label}}">{{$field->label}}</label>
+    <label for="{{$field->name}}">{{$field->label}}</label>
     <input type="date"
            class="form-control field_category {{$classes}}"
-           id="{{$field->label}}"
-           name="{{$field->label}}"
+           id="{{$field->name}}"
+           name="{{$field->name}}"
            {{$classes == 'no_categories'?'':'disabled'}}
-           value="{{old($field->label, $value)}}"
+           value="{{old($field->name, $value)}}"
     >
 </div>

--- a/src/Views/binshopsblog_admin/fields/partials/fields.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/fields.blade.php
@@ -1,0 +1,7 @@
+@foreach($fields as $field)
+    @include("binshopsblog_admin::fields.partials." . $field->typeName(), [
+        'field' => $field,
+        'value' => $post->fieldValue($field),
+        'classes' => $field->getClasses()])
+@endforeach
+

--- a/src/Views/binshopsblog_admin/fields/partials/fields.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/fields.blade.php
@@ -1,7 +1,7 @@
 @foreach($fields as $field)
     @include("binshopsblog_admin::fields.partials." . $field->typeName(), [
         'field' => $field,
-        'value' => $post->fieldValue($field),
+        'value' => $post->fieldValue($field->id),
         'classes' => $field->getClasses()])
 @endforeach
 

--- a/src/Views/binshopsblog_admin/fields/partials/number.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/number.blade.php
@@ -1,10 +1,10 @@
 <div class="form-group">
-    <label for="{{$field->label}}">{{$field->label}}</label>
+    <label for="{{$field->name}}">{{$field->label}}</label>
     <input type="number"
            class="form-control field_category {{$classes}}"
-           id="{{$field->label}}"
-           name="{{$field->label}}"
+           id="{{$field->name}}"
+           name="{{$field->name}}"
            {{$classes == 'no_categories'?'':'disabled'}}
-           value="{{old($field->label, $label)}}"
+           value="{{old($field->name, $value)}}"
     >
 </div>

--- a/src/Views/binshopsblog_admin/fields/partials/number.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/number.blade.php
@@ -1,0 +1,10 @@
+<div class="form-group">
+    <label for="{{$field->label}}">{{$field->label}}</label>
+    <input type="number"
+           class="form-control field_category {{$classes}}"
+           id="{{$field->label}}"
+           name="{{$field->label}}"
+           {{$classes == 'no_categories'?'':'disabled'}}
+           value="{{old($field->label, $label)}}"
+    >
+</div>

--- a/src/Views/binshopsblog_admin/fields/partials/number.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/number.blade.php
@@ -1,6 +1,7 @@
 <div class="form-group">
     <label for="{{$field->name}}">{{$field->label}}</label>
     <input type="number"
+           step="any"
            class="form-control field_category {{$classes}}"
            id="{{$field->name}}"
            name="{{$field->name}}"

--- a/src/Views/binshopsblog_admin/fields/partials/text.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/text.blade.php
@@ -1,0 +1,10 @@
+<div class="form-group">
+    <label for="{{$field->label}}">{{$field->label}}</label>
+    <input type="text"
+           class="form-control field_category {{$classes}}"
+           id="{{$field->label}}"
+           name="{{$field->label}}"
+           {{$classes == 'no_categories'?'':'disabled'}}
+           value="{{old($field->label, $value)}}"
+    >
+</div>

--- a/src/Views/binshopsblog_admin/fields/partials/text.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/text.blade.php
@@ -1,10 +1,10 @@
 <div class="form-group">
-    <label for="{{$field->label}}">{{$field->label}}</label>
+    <label for="{{$field->name}}">{{$field->label}}</label>
     <input type="text"
            class="form-control field_category {{$classes}}"
-           id="{{$field->label}}"
-           name="{{$field->label}}"
+           id="{{$field->name}}"
+           name="{{$field->name}}"
            {{$classes == 'no_categories'?'':'disabled'}}
-           value="{{old($field->label, $value)}}"
+           value="{{old($field->name, $value)}}"
     >
 </div>

--- a/src/Views/binshopsblog_admin/fields/partials/textarea.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/textarea.blade.php
@@ -1,10 +1,10 @@
 <div class="form-group">
     <label for="{{$field->name}}">{{$field->label}}</label>
-    <input type="textarea"
-           class="form-control field_category {{$classes}}"
-           id="{{$field->name}}"
-           name="{{$field->name}}"
-           {{$classes == 'no_categories'?'':'disabled'}}
-           value="{{old($field->name, $value)}}"
-    >
+
+    <textarea
+            id="{{$field->name}}"
+            class="form-control field_category {{$classes}}"
+            rows="4" cols="50" name="{{$field->name}}">
+        {{old($field->name, $value)}}
+    </textarea>
 </div>

--- a/src/Views/binshopsblog_admin/fields/partials/textarea.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/textarea.blade.php
@@ -1,0 +1,10 @@
+<div class="form-group">
+    <label for="{{$field->label}}">{{$field->label}}</label>
+    <input type="textarea"
+           class="form-control field_category {{$classes}}"
+           id="{{$field->label}}"
+           name="{{$field->label}}"
+           {{$classes == 'no_categories'?'':'disabled'}}
+           value="{{old($field->label, $value)}}"
+    >
+</div>

--- a/src/Views/binshopsblog_admin/fields/partials/textarea.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/textarea.blade.php
@@ -1,10 +1,10 @@
 <div class="form-group">
-    <label for="{{$field->label}}">{{$field->label}}</label>
+    <label for="{{$field->name}}">{{$field->label}}</label>
     <input type="textarea"
            class="form-control field_category {{$classes}}"
-           id="{{$field->label}}"
-           name="{{$field->label}}"
+           id="{{$field->name}}"
+           name="{{$field->name}}"
            {{$classes == 'no_categories'?'':'disabled'}}
-           value="{{old($field->label, $value)}}"
+           value="{{old($field->name, $value)}}"
     >
 </div>

--- a/src/Views/binshopsblog_admin/fields/partials/url.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/url.blade.php
@@ -1,0 +1,10 @@
+<div class="form-group">
+    <label for="{{$field->label}}">{{$field->label}}</label>
+    <input type="url"
+           class="form-control field_category {{$classes}}"
+           id="{{$field->label}}"
+           name="{{$field->label}}"
+           {{$classes == 'no_categories'?'':'disabled'}}
+           value="{{old($field->label, $value)}}"
+    >
+</div>

--- a/src/Views/binshopsblog_admin/fields/partials/url.blade.php
+++ b/src/Views/binshopsblog_admin/fields/partials/url.blade.php
@@ -1,10 +1,10 @@
 <div class="form-group">
-    <label for="{{$field->label}}">{{$field->label}}</label>
+    <label for="{{$field->name}}">{{$field->label}}</label>
     <input type="url"
            class="form-control field_category {{$classes}}"
-           id="{{$field->label}}"
-           name="{{$field->label}}"
+           id="{{$field->name}}"
+           name="{{$field->name}}"
            {{$classes == 'no_categories'?'':'disabled'}}
-           value="{{old($field->label, $value)}}"
+           value="{{old($field->name, $value)}}"
     >
 </div>

--- a/src/Views/binshopsblog_admin/layouts/sidebar.blade.php
+++ b/src/Views/binshopsblog_admin/layouts/sidebar.blade.php
@@ -89,6 +89,32 @@
 
     <li class="list-group-item list-group-color  justify-content-between lh-condensed">
         <div>
+            <h6 class="my-0"><a href="{{ route('binshopsblog.admin.fields.index') }}">Fields</a>
+                <span class="text-muted">(<?php
+                    $postCount = \BinshopsBlog\Models\BinshopsField::count();
+                    echo $postCount . " " . str_plural("Field", $postCount);
+                    ?>)</span>
+            </h6>
+
+
+            <small class="text-muted">Post fields</small>
+
+            <div class="list-group ">
+                <a href='{{ route('binshopsblog.admin.fields.index') }}'
+                   class='list-group-item list-group-color list-group-item list-group-color-action  @if(\Request::route()->getName() === 'binshopsblog.admin.fields.index') active @endif  '><i
+                            class="fa fa-object-group fa-fw" aria-hidden="true"></i>
+                    All Fields</a>
+                <a href='{{ route('binshopsblog.admin.fields.create_field') }}'
+                   class='list-group-item list-group-color list-group-item list-group-color-action  @if(\Request::route()->getName() === 'binshopsblog.admin.fields.create_field') active @endif  '><i
+                            class="fa fa-plus fa-fw" aria-hidden="true"></i>
+                    Add Field</a>
+            </div>
+        </div>
+
+    </li>
+
+    <li class="list-group-item list-group-color  justify-content-between lh-condensed">
+        <div>
             <h6 class="my-0"><a href="{{ route('binshopsblog.admin.images.upload') }}">Languages</a></h6>
 
             <div class="list-group ">

--- a/src/Views/binshopsblog_admin/posts/form.blade.php
+++ b/src/Views/binshopsblog_admin/posts/form.blade.php
@@ -8,7 +8,6 @@
         @endforeach
     </select>
 </div>
-
 <div class="form-group">
     <label for="blog_title">Blog Post Title</label>
     <input type="text" class="form-control" required id="blog_title" aria-describedby="blog_title_help" name='title'
@@ -100,6 +99,7 @@
     </div>
 </div>
 
+@include("binshopsblog_admin::fields.partials.fields", ['fields' => $fields])
 
 @if(config("binshopsblog.use_custom_view_files",true))
     <div class="form-group">
@@ -198,7 +198,8 @@
 
         @forelse($cat_ts as $translation)
             <div class="form-check col-sm-6">
-                <input class="" type="checkbox" value="1"
+                <input class="category_checkbox" type="checkbox" value="1"
+                       onclick="toggleCheckbox(event)"
                        @if(old("category.".$translation->category_id, $post->categories->contains($translation->category_id))) checked='checked'
                        @endif name='category[{{$translation->category_id}}]' id="category_check{{$translation->category_id}}">
                 <label class="form-check-label" for="category_check{{$translation->category_id}}">
@@ -225,10 +226,40 @@
 <script>
     SHOULD_AUTO_GEN_SLUG = false;
 
+    function toggleCheckbox(event){
+        let categoryId = event.target.id.replace('category_check','');
+        if (event.target.checked){
+            let fieldCategories = document.getElementsByClassName('field_category_' + categoryId)
+            for (let i=0; i < fieldCategories.length; i++) {
+                fieldCategories[i].disabled = false;
+            }
+            return
+        }
+        // We cannot be sure which categories are selected, therefore, disable everything and check everything.
+        let fieldCategories = document.getElementsByClassName('field_category')
+        for (let i=0; i < fieldCategories.length; i++) {
+            if (fieldCategories[i].classList.contains('no_categories')) {
+                continue;
+            }
+            fieldCategories[i].disabled = true;
+        }
+
+        let categoriesCheckbox = document.getElementsByClassName('category_checkbox')
+        for (let i=0; i < categoriesCheckbox.length; i++) {
+            if (categoriesCheckbox[i].checked) {
+                let categoryId = categoriesCheckbox[i].id.replace('category_check','');
+                let fieldCategories = document.getElementsByClassName('field_category_' + categoryId)
+                for (let i=0; i < fieldCategories.length; i++) {
+                    fieldCategories[i].disabled = false;
+                }
+            }
+        }
+    }
+
+
+
     /* Generate the slug field, if it was not touched by the user (or if it was an empty string) */
     function populate_slug_field() {
-
-//        alert("A");
         var cat_slug = document.getElementById('blog_slug');
 
         if (cat_slug.value.length < 1) {
@@ -245,7 +276,6 @@
                 .substring(0,99); // limit str length
 
         }
-
     }
 
     if (document.getElementById("blog_slug").value.length < 1) {

--- a/src/Views/binshopsblog_admin/posts/form.blade.php
+++ b/src/Views/binshopsblog_admin/posts/form.blade.php
@@ -225,7 +225,7 @@
 
 <script>
     SHOULD_AUTO_GEN_SLUG = false;
-
+    enableField()
     function toggleCheckbox(event){
         let categoryId = event.target.id.replace('category_check','');
         if (event.target.checked){
@@ -243,7 +243,10 @@
             }
             fieldCategories[i].disabled = true;
         }
+        enableField()
+    }
 
+    function enableField() {
         let categoriesCheckbox = document.getElementsByClassName('category_checkbox')
         for (let i=0; i < categoriesCheckbox.length; i++) {
             if (categoriesCheckbox[i].checked) {
@@ -255,7 +258,6 @@
             }
         }
     }
-
 
 
     /* Generate the slug field, if it was not touched by the user (or if it was an empty string) */

--- a/src/routes.php
+++ b/src/routes.php
@@ -135,6 +135,27 @@ Route::group(['middleware' => ['web'], 'namespace' => '\BinshopsBlog\Controllers
 
         });
 
+        Route::group(['prefix' => 'fields'], function () {
+            Route::get('/',
+                'BinshopsFieldAdminController@index')
+                ->name('binshopsblog.admin.fields.index');
+
+            Route::get('/add_category',
+                'BinshopsFieldAdminController@create_field')
+                ->name('binshopsblog.admin.fields.create_field');
+
+            Route::post('/store_field',
+                'BinshopsFieldAdminController@store_field')
+                ->name('binshopsblog.admin.fields.store_field');
+
+            Route::get('/edit_field/{fieldId}',
+                'BinshopsFieldAdminController@edit_field')
+                ->name('binshopsblog.admin.fields.edit_field');
+
+            Route::delete('/delete_field/{fieldId}',
+                'BinshopsFieldAdminController@destroy_field')
+                ->name('binshopsblog.admin.fields.destroy_field');
+        });
 
         Route::group(['prefix' => 'languages'], function () {
 


### PR DESCRIPTION
New Features:
Admin can add custom fields. 
Admin can define field type of custom field
Admin can add additional validation rules
Admin can add categories to fields. 
Fields which have no category are used on all posts
when a field has a category, this field is only used on posts which have the same category.

By default only the fields with values are displayed below a post.

Improvements:
Added transactions when saving a post to avoid database inconsistencies.