### PR TITLE
fix mistake: author not rendered in single post view

### DIFF
--- a/src/Views/binshopsblog/partials/full_post_details.blade.php
+++ b/src/Views/binshopsblog/partials/full_post_details.blade.php
@@ -25,5 +25,5 @@
 
 Posted <strong>{{$post->post->posted_at->diffForHumans()}}</strong>
 
-@includeWhen($post->author,"binshopsblog::partials.author",['post'=>$post])
+@includeWhen($post->post->author,"binshopsblog::partials.author",['post'=>$post->post])
 @includeWhen($categories,"binshopsblog::partials.categories",['categories'=>$categories])


### PR DESCRIPTION
The $post variable in full post detail view is of class PostTranslation, $post->author doesn't exist.

On the other hand, $post->post->author is what was probably meant