### PR TITLE
Update CKEDITOR free version in form.blade.php

### DIFF
--- a/src/Views/binshopsblog_admin/posts/form.blade.php
+++ b/src/Views/binshopsblog_admin/posts/form.blade.php
@@ -257,11 +257,13 @@
 </script>
 
 @if( config("binshopsblog.use_wysiwyg") && config("binshopsblog.echo_html"))
-    <script src="//cdn.ckeditor.com/4.24.0-lts/full/ckeditor.js"></script>
+    <script src="//cdn.ckeditor.com/4.22.1/full/ckeditor.js"></script>
 
     <script>
-        if( typeof(CKEDITOR) !== "undefined" ) {
-            CKEDITOR.replace('post_body');
+        if (typeof(CKEDITOR) !== "undefined") {
+            CKEDITOR.replace('post_body', {
+                versionCheck: false
+            });
         }
     </script>
 @endif


### PR DESCRIPTION
CKEditor 4 is EOL since June 2023. We can use it only for free latest version 4.22.1 with disabled version checking